### PR TITLE
Make multi selection toggleable

### DIFF
--- a/src/components/accordian/index.jsx
+++ b/src/components/accordian/index.jsx
@@ -29,7 +29,7 @@ export default function Accordian() {
   return (
     <div className="acc-wrapper">
       <button onClick={() => setEnableMultiSelection(!enableMultiSelection)}>
-        Enable Multi Selection
+        {toggleSelection ? "Disable Multi Selection" : "Enable Multi Selection"}
       </button>
       <div className="accordian">
         {data && data.length > 0 ? (


### PR DESCRIPTION
Replaced static "Enable Multi Selection" button label with dynamic text based on toggleSelection state. Now displays "Enable" or "Disable Multi Selection" based on current selection mode.